### PR TITLE
fix: fix a bug that Ast instance doesn't have parent

### DIFF
--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -128,4 +128,14 @@ const b = 2;
 
     expect(getGlobalConfig()).toEqual({ typeKey: 'type' });
   });
+
+  test('should have parent in child ast', () => {
+    const a = unified()
+      .use(markdown)
+      .parse('Hello **world**!');
+    const ast = new Ast(a);
+    const children = ast.node.children[0].children;
+    expect(children.length).toStrictEqual(3);
+    expect(children[0].value).toStrictEqual('Hello ');
+  });
 });

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -133,9 +133,29 @@ const b = 2;
     const a = unified()
       .use(markdown)
       .parse('Hello **world**!');
-    const ast = new Ast(a);
-    const children = ast.node.children[0].children;
-    expect(children.length).toStrictEqual(3);
-    expect(children[0].value).toStrictEqual('Hello ');
+
+    const mock = jest.fn((ast: Ast) => {
+      expect(ast.parent.node.type).toStrictEqual('paragraph');
+    });
+
+    class MyPlugin extends Plugin {
+      post(): void {
+      }
+
+      pre(): void {
+      }
+
+      visitor(): any {
+        return {
+          strong: mock
+        };
+      }
+
+    }
+
+    new Ast(a).traverse([new MyPlugin({
+      throwError: undefined
+    })]);
+    expect(mock).toBeCalled()
   });
 });

--- a/src/Ast.ts
+++ b/src/Ast.ts
@@ -5,11 +5,11 @@ import { Plugin } from './Plugin';
 
 export class Ast {
   node: Unist.Node;
-  parent: Unist.Node;
+  parent: Ast;
   text: string;
   skipped: boolean;
 
-  constructor(node: Unist.Node, parent?: Unist.Parent, text?: string) {
+  constructor(node: Unist.Node, parent?: Ast, text?: string) {
     this.node = node;
     this.parent = parent;
     // 文本、代码
@@ -59,7 +59,7 @@ export class Ast {
 
     // 处理子元素
     if (Array.isArray(children) && !this.skipped) {
-      children.forEach(child => new Ast(child, undefined, this.text).process(plugins));
+      children.forEach(child => new Ast(child, this, this.text).process(plugins));
     }
   }
 


### PR DESCRIPTION
重构时不小心把 AST 构造函数的 parent 参数传入了个 undefined，sorry~

- [x] 传入正确的参数给 `Ast()`
- [x] 补充相应的单元测试
- [x] 原先的 global configure 测试有副作用，会影响后面的测试结果，修复之